### PR TITLE
Fix template check in plugin

### DIFF
--- a/core/components/fileman/elements/plugins/fileman.php
+++ b/core/components/fileman/elements/plugins/fileman.php
@@ -21,7 +21,7 @@ switch ($modx->event->name) {
         if ($templates != '') {
             $templates = array_map('trim', explode(',', $templates));
             $template = $resource->get('template');
-            if (!in_array($template, $templatelist)) {
+            if (!in_array($template, $templates)) {
                 return;
             }
         }


### PR DESCRIPTION
Plugin was throwing an error while using the `fileman_templates` system setting, due to an undefined variable.