### PR TITLE
Added a check in processor (PHP8)

### DIFF
--- a/core/components/fileman/src/Processors/File/GetList.php
+++ b/core/components/fileman/src/Processors/File/GetList.php
@@ -98,7 +98,7 @@ class GetList extends GetListProcessor
     public function prepareRow(xPDOObject $object)
     {
         $array = $object->toArray();
-        $array['resource_pagetitle'] = strip_tags($array['resource_pagetitle']);
+        if(isset($array['resource_pagetitle'])) $array['resource_pagetitle'] = strip_tags($array['resource_pagetitle']);
         return $array;
     }
 


### PR DESCRIPTION
I've added an aditional check, because the error log kept filling up in PHP 8.

Example:
```
[2024-03-28 13:40:58] (ERROR @ /var/www/html/core/components/fileman/src/Processors/File/GetList.php : 101) PHP warning: Undefined array key "resource_pagetitle"
```