### PR TITLE
Update Upload.php

### DIFF
--- a/core/components/fileman/src/Processors/File/Upload.php
+++ b/core/components/fileman/src/Processors/File/Upload.php
@@ -254,8 +254,8 @@ class Upload extends Processor
      */
     private function preparePath($path)
     {
-        $search = array('{year}', '{month}', '{day}', '{user}', '{resource}');
-        $replace = array(date('Y'), date('m'), date('d'), $this->modx->user->get('id'), $this->getProperty('resource_id'));
+        $search = array('{year}', '{month}', '{day}', '{user}', '{resource}', '{resourceIdPath}');
+        $replace = array(date('Y'), date('m'), date('d'), $this->modx->user->get('id'), $this->getProperty('resource_id'),implode('/', str_split(strval($this->getProperty('resource_id')))) . '/');
 
         return str_replace($search, $replace, $path);
     }


### PR DESCRIPTION
“Added an option to use {resourceIdPath}, which generates the path based on the resource ID (e.g. 234 becomes 2/3/4/).”

Clients often want to display a file from specific content in another place, but it is difficult to find it. If the path is defined with {year}, {month}, {day}, you have to know when the file was uploaded in order to locate it. Using {user} is also not practical. The best option is to use {resource}, because users can quickly find the desired files based on the ID. However, this approach causes problems when displaying the structure in the tree menu, since all folders are on the same level.

The prepared solution {resourceIdPath} converts the path into folders created based on the content ID, which allows easy searching by ID and ensures that there are no more than 10 folders on a single level at any time.